### PR TITLE
Add support for retrotwetch posts

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const classify = (script) => {
 		if (twetch) {
 			tag = twetch;
 		} else if (isRunOut(script)) {
-			tag = 'run';
+			return runApp(script);
 		}
 	} else if (is21e8Out(script)) {
 		tag = '21e8';

--- a/lib/run-app.js
+++ b/lib/run-app.js
@@ -1,0 +1,5 @@
+const runApp = (script) => {
+    return script.chunks[4].buf ? script.chunks[4].buf.toString('utf8') : 'run';
+};
+
+module.exports = runApp;


### PR DESCRIPTION
Add condition in twetch output evaluation if the post content contains the retrotwetch cashtag $osg.

Node version must support 14 or up to support optional chaining.
