### PR TITLE
Add support for retrotwetch tag

### DIFF
--- a/lib/is-twetch-out.js
+++ b/lib/is-twetch-out.js
@@ -16,6 +16,9 @@ const isTwetchOut = script => {
 		} catch (e) {}
 	}
 
+	if (instance?.args[1].includes('$osg')) {
+        return 'retrotwetch';
+    }
 	return (
 		!!instance && instance.actionName && 'Twetch ' + instance.actionName.split('/')[1].split('@')[0]
 	);


### PR DESCRIPTION
Add condition to twetch post output evaluation if content of post contains the cashtag $osg.

If so, return retrotwetch as the tag. Code change only valid on Node.js v14 or higher due to use of optional chaining.